### PR TITLE
Add per-channel working directory support

### DIFF
--- a/src/queue.ts
+++ b/src/queue.ts
@@ -39,4 +39,5 @@ export interface ClaudeJob {
     resume: boolean;
     userId: string;
     username: string;
+    workingDir?: string;
 }

--- a/src/spawner.ts
+++ b/src/spawner.ts
@@ -21,6 +21,7 @@ interface SpawnOptions {
     sessionId: string;
     resume: boolean;
     systemPrompt?: string;
+    workingDir?: string;
 }
 
 /**
@@ -45,9 +46,11 @@ function getDatetimeContext(): string {
  * Spawn Claude CLI and return the response
  */
 export async function spawnClaude(options: SpawnOptions): Promise<string> {
-    const { prompt, sessionId, resume, systemPrompt } = options;
+    const { prompt, sessionId, resume, systemPrompt, workingDir } = options;
 
+    const cwd = workingDir || process.env.CLAUDE_WORKING_DIR || process.cwd();
     log(`Spawning Claude - Session: ${sessionId}, Resume: ${resume}`);
+    log(`Working directory: ${cwd}`);
 
     // Build CLI arguments
     const args = ['claude'];
@@ -79,7 +82,7 @@ export async function spawnClaude(options: SpawnOptions): Promise<string> {
 
     // Spawn the process
     const proc = Bun.spawn(args, {
-        cwd: process.env.CLAUDE_WORKING_DIR || process.cwd(),
+        cwd,
         env: {
             ...process.env,
             TZ: TIMEZONE,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -24,7 +24,7 @@ const connection = new IORedis({
 const worker = new Worker<ClaudeJob>(
     'claude',
     async (job: Job<ClaudeJob>) => {
-        const { prompt, threadId, sessionId, resume, username } = job.data;
+        const { prompt, threadId, sessionId, resume, username, workingDir } = job.data;
 
         log(`Processing job ${job.id} for ${username}`);
         log(`Session: ${sessionId}, Resume: ${resume}`);
@@ -35,6 +35,7 @@ const worker = new Worker<ClaudeJob>(
                 prompt,
                 sessionId,
                 resume,
+                workingDir,
             });
 
             // Send response to Discord thread


### PR DESCRIPTION
## Summary

Adds support for per-channel working directories so Claude operates in the correct project context.

- **One-time channel setup**: `/cord config dir ~/Code/myproject`
- **Normal usage**: Just `@bot do something` - uses channel's configured directory
- **Per-thread override**: `@bot [/other/project] do something` - overrides for this thread only

**Fallback chain**: Thread override → Channel default → `CLAUDE_WORKING_DIR` env → `process.cwd()`

## Changes

- `src/db.ts`: Add `channels` table and `working_dir` column to `threads` table
- `src/bot.ts`: Register `/cord config` slash command, resolve working dir from message/channel/env, expand `~` to home directory
- `src/queue.ts`: Add `workingDir` to job interface
- `src/worker.ts`: Pass `workingDir` through to spawner
- `src/spawner.ts`: Use resolved working directory as `cwd` for Claude process

## Test plan

- [x] `/cord config dir ~/path/to/project` saves to database (tilde expands correctly)
- [x] `@bot what files are here?` uses channel's configured directory
- [x] `@bot [/tmp] what files are here?` overrides with `/tmp` for that thread
- [x] Unconfigured channel falls back to `CLAUDE_WORKING_DIR` or `process.cwd()`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)